### PR TITLE
A couple of fixes to occi and dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ADD vomses /etc/vomses
 ADD vomsdir/fedcloud.egi.eu /etc/grid-security/vomsdir/fedcloud.egi.eu
 RUN chmod 644 /etc/vomses /etc/grid-security/vomsdir/*
     
-RUN fetch-crl -v
+RUN fetch-crl -v || true
 
 WORKDIR /data
 

--- a/occi
+++ b/occi
@@ -5,11 +5,11 @@ if [ $1 = "--voms-proxy-init" ]; then
     docker rm occi-voms-proxy 2>/dev/null
     docker run -it -v ~/.globus:/root/.globus:ro \
         --name occi-voms-proxy marklee77/egi-fedcloud-client /bin/bash -c \
-        "fetch-crl -v && voms-proxy-init -voms fedcloud.egi.eu --rfc --dont_verify_ac"
+        "(fetch-crl -v || true) && voms-proxy-init -voms fedcloud.egi.eu --rfc --dont_verify_ac"
     exit 0
 fi
 
-docker run --volumes-from occi-voms-proxy -v $PWD:/data:rw -it \
+docker run --rm --volumes-from occi-voms-proxy -v $PWD:/data:rw -it \
     marklee77/egi-fedcloud-client \
         occi --auth x509 --user-cred /tmp/x509up_u0 --voms \
             --endpoint ${OCCI_ENDPOINT} $@


### PR DESCRIPTION
- allows Dockerfile and occi scripts to proceed even if fetch-crl cannot retrieve all CRLs (it was failing to connect to a couple of international sites)
- removes temporary containers after calling occi (added --rm flag)
